### PR TITLE
在包中创建Cat类

### DIFF
--- a/src/main/java/my/cute/Cat.java
+++ b/src/main/java/my/cute/Cat.java
@@ -1,0 +1,4 @@
+package my.cute;
+
+public class Cat {
+}


### PR DESCRIPTION
包名由目录结构确定，用来区分功能结构。每个类都处在一个包中。
不同包中有相同的类，就需要至少有一个声明全限定类名。
Calss是最小的结构